### PR TITLE
I've updated the TypeScript `moduleResolution` setting in your common…

### DIFF
--- a/packages/@n8n/typescript-config/tsconfig.common.json
+++ b/packages/@n8n/typescript-config/tsconfig.common.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"strict": true,
 		"module": "commonjs",
-		"moduleResolution": "node",
+		"moduleResolution": "node16",
 		"target": "es2021",
 		"lib": ["es2021", "es2022.error", "dom"],
 		"removeComments": true,


### PR DESCRIPTION
… configuration from 'node' to 'node16'.

This change should address a number of 'Cannot find module' errors (TS2307) you were seeing across different packages. The 'node16' setting offers improved handling of `package.json` 'exports' fields, which are utilized by workspace packages such as 'n8n-workflow'. This leads to better resolution of type declarations.

I also anticipate this will enhance the reliability of your build process and could resolve runtime errors related to missing 'dist' files.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
